### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI - Full Stack Testing
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/5](https://github.com/CreoDAMO/REPAR/security/code-scanning/5)

To fix the issue, explicitly set a `permissions` block at the top (workflow-level) of `.github/workflows/ci.yml. This applies to all jobs unless specifically overridden at the job level. Since none of the jobs require write permissions, the minimal block should be set as `contents: read`, which covers code checkout and read-only actions, and allows the use of `$GITHUB_STEP_SUMMARY` (unless you plan to restrict further using the `id-token` or `statuses`, which is not necessary for this workflow). Insert this block immediately below the `name:` and above the `on:` block. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
