### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/ignite-cli/ignite/services/plugin/grpc/v1/interface_flag.go
+++ b/ignite-cli/ignite/services/plugin/grpc/v1/interface_flag.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"strconv"
 	"strings"
+	"math"
 
 	"github.com/spf13/pflag"
 
@@ -75,7 +76,10 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 		if err != nil {
 			return newDefaultFlagValueError(cobraFlagTypeUint, f.DefaultValue)
 		}
-
+		// Check upper bound before converting
+		if v > uint64(math.MaxUint) {
+			return newDefaultFlagValueError(cobraFlagTypeUint, f.DefaultValue)
+		}
 		fs.UintP(f.Name, f.Shorthand, uint(v), f.Usage)
 		if f.Value != "" {
 			if err := fs.Set(f.Name, f.Value); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/7](https://github.com/CreoDAMO/REPAR/security/code-scanning/7)

The best way to fix this problem is to check that the value parsed from the string (`v`) does not exceed the maximum value storable in a `uint` before casting to `uint`. For platform compatibility, use the `math` package to retrieve the correct maximum value for `uint`. You should check `v <= math.MaxUint` before casting; and (since `v` is unsigned) no need to check lower-bound, but for semantic validation (e.g., `fs.UintP`) you may want to check it's also non-negative, though `strconv.ParseUint` guarantees that. 

So, in `ignite-cli/ignite/services/plugin/grpc/v1/interface_flag.go`, modify the section starting at line 74 (case `Flag_TYPE_FLAG_UINT`) to add an explicit upper-bound check before the conversion. If the bound is exceeded, return an error.

You will need to import the `math` package at the top of the file if not already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
