### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -82,6 +82,8 @@ jobs:
     name: Initialize Local Testnet
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/4](https://github.com/CreoDAMO/REPAR/security/code-scanning/4)

To fix the problem, explicitly set a `permissions:` block with least privilege required for the job. For the `initialize-testnet` job, explicit permission of at least `contents: read` should be set, unless more is needed. Since the workflow may have multiple jobs, and the CodeQL finding is specific to the job, add a `permissions:` block to the `initialize-testnet` job spec (line 82 or just above `steps:`). No additional libraries or code changes beyond editing the yaml file are needed; just insert the following block:
```yaml
permissions:
  contents: read
```
This restricts the default GITHUB_TOKEN permissions and follows CodeQL recommendations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
