### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/ignite-cli/ignite/services/plugin/grpc/v1/interface_flag.go
+++ b/ignite-cli/ignite/services/plugin/grpc/v1/interface_flag.go
@@ -77,9 +77,14 @@ func (f *Flag) ExportToFlagSet(fs *pflag.FlagSet) error {
 			return newDefaultFlagValueError(cobraFlagTypeUint, f.DefaultValue)
 		}
 		// Check upper bound before converting to platform uint
-		var maxUint uint64 = math.MaxUint32
-		if strconv.IntSize == 64 {
+		var maxUint uint64
+		switch strconv.IntSize {
+		case 32:
+			maxUint = math.MaxUint32
+		case 64:
 			maxUint = math.MaxUint64
+		default:
+			return newDefaultFlagValueError(cobraFlagTypeUint, f.DefaultValue)
 		}
 		if v > maxUint {
 			return newDefaultFlagValueError(cobraFlagTypeUint, f.DefaultValue)


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/7](https://github.com/CreoDAMO/REPAR/security/code-scanning/7)

To fix the integer conversion issue, always check that the parsed value (`v` from `strconv.ParseUint`) fits into the actual platform-dependent `uint` type before converting. Since Go's `uint` is either 32 or 64 bits and represented by `strconv.IntSize`, use this to set an upper bound: if `strconv.IntSize == 32`, the maximum is `math.MaxUint32`; if `strconv.IntSize == 64`, the maximum is `math.MaxUint64`. Convert up to this bound for all future platforms.

To clarify intent and for readability, use a switch statement to map the `strconv.IntSize` variable to the correct maximum value; preserve the code logic for clarity. Make sure no other changes to the handling or usage of `v` are introduced.

Change only the relevant code in the `Flag_TYPE_FLAG_UINT` handling block in the `ExportToFlagSet` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
