### PR TITLE
Potential fix for code scanning alert no. 9: Inefficient regular expression

### DIFF
--- a/dexplorer/src/utils/helper.ts
+++ b/dexplorer/src/utils/helper.ts
@@ -157,7 +157,7 @@ export const getTypeMsg = (typeUrl: string): string => {
 export const isValidUrl = (urlString: string): Boolean => {
   var urlPattern = new RegExp(
     '^(https?:\\/\\/)?' + // validate protocol
-      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // validate domain name
+      '((([a-z\\d](?:[a-z\\d-]*[a-z\\d])?)\\.)+[a-z]{2,}|' + // validate domain name
       '((\\d{1,3}\\.){3}\\d{1,3}))' + // validate OR ip (v4) address
       '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // validate port and path
       '(\\?[;&a-z\\d%_.~+=-]*)?' + // validate query string


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/9](https://github.com/CreoDAMO/REPAR/security/code-scanning/9)

To fix the inefficiency, the ambiguous alternation in the domain-matching part of the regular expression should be modified so that adjacent repetition no longer allows overlapping matches. Specifically, the problematic part is `([a-z\d]([a-z\d-]*[a-z\d])*)`, meant to match domain labels (separated by dots). The pathological ambiguity comes from allowing both `[a-z\d]` and `[a-z\d-]` at various positions. To fix this without changing the set of accepted strings, the recommended solution is to rewrite the label-matching pattern to avoid overlapping matches: instead of matching arbitrary sequences of `[a-z\d-]`, require that labels only start and end with `[a-z\d]`, with hyphens only allowed in the middle (per the formal rules for domain names). A standard, efficient way to match this is:

`[a-z\d](?:[a-z\d-]*[a-z\d])?`

Replace the domain-matching part on line 160 with this pattern, and use it in the repeated group that matches multiple labels separated by dots. Also, contextually confirm that you're only editing code you're shown, so confine changes to the `isValidUrl` function's regex.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
