### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/docs/financials/calculator/package.json
+++ b/docs/financials/calculator/package.json
@@ -74,7 +74,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@builder.io/vite-plugin-jsx-loc": "^0.1.1",

--- a/docs/financials/calculator/server/_core/vite.ts
+++ b/docs/financials/calculator/server/_core/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
@@ -60,8 +61,16 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // Rate limiter: max 100 requests per 15 minutes per IP
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", limiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/13](https://github.com/CreoDAMO/REPAR/security/code-scanning/13)

To fix the issue, we should add rate limiting middleware to protect the file-system-accessing handler (`app.use("*", ...)` starting on line 64) in `serveStatic`. The industry-standard package for Express is `express-rate-limit`, which can be added and configured (e.g., restricting requests per minute/hour). The rate-limiting middleware should be applied before the handler that performs expensive operations. Since we can only edit the shown snippet, we add the required import, instantiate a limiter (e.g., 100 requests per 15 minutes), and apply it before the file-serving route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
