### PR TITLE
Potential fix for code scanning alert no. 12: Missing rate limiting

### DIFF
--- a/docs/financials/calculator/package.json
+++ b/docs/financials/calculator/package.json
@@ -74,7 +74,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@builder.io/vite-plugin-jsx-loc": "^0.1.1",

--- a/docs/financials/calculator/server/_core/vite.ts
+++ b/docs/financials/calculator/server/_core/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
@@ -21,7 +22,15 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+  
+  // Rate limit: max 100 requests per 15 minutes per IP on this catch-all route
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100,
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false,
+  });
+  app.use("*", limiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/12](https://github.com/CreoDAMO/REPAR/security/code-scanning/12)

**General approach:**  
Add a rate limiting middleware (such as with `express-rate-limit`) before the expensive handler on the `app` object. This should be applied narrowly (to the route in question) or for all routes, as appropriate.

**Best fix without changing functionality:**  
- Install and import the `express-rate-limit` package.
- Configure a new rate limiting instance (for example: 100 requests per 15 minutes per IP).
- Apply this as middleware on the `*` route before your async handler.
- Only touch the shown code in `docs/financials/calculator/server/_core/vite.ts`.

**What is needed:**  
- Import `express-rate-limit` at the top of the file.
- Add rate limiting middleware before the handler that accesses the filesystem.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
