### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cerberus-audit.yml
+++ b/.github/workflows/cerberus-audit.yml
@@ -3,6 +3,8 @@
 # Provides continuous security monitoring for the Aequitas Protocol
 
 name: Cerberus Security Audit
+permissions:
+  contents: read
 
 on:
   push:
@@ -141,6 +143,9 @@ jobs:
   
   create-patches:
     needs: security-audit
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/17](https://github.com/CreoDAMO/REPAR/security/code-scanning/17)

The best fix is to add an explicit `permissions` block to the workflow to ensure the jobs run with the least privilege required.  
- Set the `permissions` block at the workflow (top-level), restricting to `contents: read` by default for all jobs.
- Where a job needs more permissions (such as `create-patches` for branch and PR creation), override with a specific `permissions` block for that job, granting only `contents: write` and `pull-requests: write`.
- This change should be made at the start of the workflow file (just after the `name:` field for workflow-level), and in the specific job(s) requiring more for job-level.

Steps:
1. Add 
   ```yaml
   permissions:
     contents: read
   ```
   globally after the `name` field.
2. Add 
   ```yaml
   permissions:
     contents: write
     pull-requests: write
   ```
   in the `create-patches:` job, before `runs-on:`.

No new methods, imports, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
