### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/auditor/main.py
+++ b/auditor/main.py
@@ -138,17 +138,25 @@ async def audit_document(file_path: str, background_tasks: BackgroundTasks):
             status_code=503,
             detail="Orchestrator not available"
         )
-    
-    if not Path(file_path).exists():
+
+    AUDIT_ROOT = os.path.abspath("auditable_documents")
+    # Always resolve file_path relative to AUDIT_ROOT, and prevent traversal
+    safe_path = os.path.normpath(os.path.join(AUDIT_ROOT, file_path))
+    if not safe_path.startswith(AUDIT_ROOT):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid file path."
+        )
+    if not os.path.isfile(safe_path):
         raise HTTPException(
             status_code=404,
             detail=f"File not found: {file_path}"
         )
-    
+
     audit_id = f"doc_audit_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}"
-    
-    background_tasks.add_task(run_document_audit, audit_id, file_path)
-    
+
+    background_tasks.add_task(run_document_audit, audit_id, safe_path)
+
     return AuditResponse(
         audit_id=audit_id,
         status="started",


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/20](https://github.com/CreoDAMO/REPAR/security/code-scanning/20)

To fix the issue, access to files should be restricted so that user input (here, `file_path`) cannot reference files outside a controlled/safe directory. The recommended approach is to designate a "root" audit directory and ensure that any `file_path` provided is normalized and checked to confirm it resides within that directory. This can be achieved by joining the root and user path, normalizing the result with `os.path.normpath` (or using `Path.resolve()`), and then confirming the resolved result begins with the desired root path.

Concretely, in the block handling the `/audit/document` endpoint, the following needs to be done:
- Define a root directory for auditable documents (e.g., `AUDIT_ROOT`).
- When `file_path` is received, join it with the root directory, normalize the full path, and check that the resulting path is within the allowed directory.
- Use the resolved path in all filesystem operations (including `.exists()` check and later usage).
- Add any required imports (`os` is already imported, but potentially more from pathlib).

Changes are only to this endpoint (`audit_document`) in auditor/main.py. 

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
