### PR TITLE
Potential fix for code scanning alert no. 21: Information exposure through an exception

### DIFF
--- a/auditor/main.py
+++ b/auditor/main.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict, List
 from datetime import datetime
 from pathlib import Path
 import sys
+import logging
 
 # Add the auditor directory to the path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -178,10 +179,11 @@ async def run_audit(audit_id: str, target_directory: str):
         audit_history.append(current_audit)
         
     except Exception as e:
+        logging.error(f"Audit {audit_id} failed: {e}", exc_info=True)
         current_audit = {
             **current_audit,
             "status": "failed",
-            "error": str(e),
+            "error": "An internal error occurred while running the audit.",
             "failed_at": datetime.utcnow().isoformat()
         }
         audit_history.append(current_audit)


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/21](https://github.com/CreoDAMO/REPAR/security/code-scanning/21)

To fix this vulnerability, the API endpoint should not expose the raw exception message to the user. Instead, when an audit fails, the `"error"` field in `current_audit` should be replaced with a generic error message safe for external exposure (e.g., "An internal error occurred" or similar). Meanwhile, the real exception details—such as the string representation of the exception and the stack trace if desired—should be logged server-side using Python's `logging` module for diagnosis, but never returned over the API.  

**Best fix:**  
- In `run_audit()`, inside the `except Exception as e:` block, log the real error (using `logging.error()` with the stack trace using `exc_info=True`), but set `current_audit["error"]` to a generic message.
- No changes required in `/audit/status` handler, as long as only safe messages are returned in the `"error"` field.
- Add an import for the `logging` module at the top of the file if not present.

**Files/lines to change:**  
- auditor/main.py:  
  - Add the `import logging` statement (near other imports).
  - In the `run_audit()` function, update the error-handling block to log the exception with details, but store a generic error message in `current_audit["error"]`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
