### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-to-digitalocean.yml
+++ b/.github/workflows/deploy-to-digitalocean.yml
@@ -19,6 +19,8 @@
 #   - ANTHROPIC_API_KEY: Anthropic API key for the Cerberus Engine
 
 name: Deploy to DigitalOcean
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: # Allows manual triggering from the GitHub Actions tab


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/19](https://github.com/CreoDAMO/REPAR/security/code-scanning/19)

To fix the problem, add a top-level `permissions` block to the workflow YAML file. The minimal recommended value for most workflows is `contents: read`, which allows the workflow and any jobs or actions to read the repository code but not modify its contents (unless stricter write permissions are needed for features like PR updates, checks, or issues—which aren't needed here).

**Instructions:**  
- In `.github/workflows/deploy-to-digitalocean.yml`, insert (or merge) the following block near the top, after `name: ...` and before `on: ...`:
  ```yaml
  permissions:
    contents: read
  ```
- This applies least privilege to all jobs in the workflow unless overridden locally.

No additional imports, methods, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
