### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-to-digitalocean.yml
+++ b/.github/workflows/deploy-to-digitalocean.yml
@@ -14,6 +14,8 @@
 #   - DO_SSH_PRIVATE_KEY: The private SSH key that corresponds to a public key added to the Droplet's authorized_keys.
 
 name: Deploy to DigitalOcean
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: # Allows manual triggering from the GitHub Actions tab


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/23](https://github.com/CreoDAMO/REPAR/security/code-scanning/23)

To fix the problem, you should add a `permissions` block at the root of the workflow (just after the `name` field and before `on:`), explicitly declaring the minimal required privileges. For this workflow, which only needs to check out code (read access to repository contents), the following is sufficient:

```yaml
permissions:
  contents: read
```

This addition ensures the workflow only has read-only access to repository contents via `GITHUB_TOKEN`, and nothing else. No job or step in this workflow appears to require further write permissions (no issues, no pull requests, etc.). You should place this block right after the `name: Deploy to DigitalOcean` declaration. No imports or other method or definition changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
