### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-to-digitalocean.yml
+++ b/.github/workflows/deploy-to-digitalocean.yml
@@ -15,6 +15,9 @@
 
 name: Deploy to DigitalOcean
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch: # Allows manual triggering from the GitHub Actions tab
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/23](https://github.com/CreoDAMO/REPAR/security/code-scanning/23)

The fix is to add an explicit `permissions` block to the workflow, either at the root (for all jobs) or within the specific job under `jobs:`. The permissions should be set to the absolute minimum necessary for the workflow to complete. For this workflow, which only checks out code and deploys via SSH to DigitalOcean, only the `contents: read` permission is required for actions like `actions/checkout`. No other GitHub API access is needed. You should add the following block at the root level of the workflow (e.g., after the `name:` line), but it is also acceptable to add under the `deploy` job specifically. The best-practice is root-level so all future jobs inherit the same restricted permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
