### PR TITLE
Potential fix for code scanning alert no. 27: Information exposure through an exception

### DIFF
--- a/ace/ai-sidecar/ace_sidecar.py
+++ b/ace/ai-sidecar/ace_sidecar.py
@@ -296,7 +296,7 @@ def optimize_cost():
         
     except Exception as e:
         logger.error(f"Cost optimization error: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error has occurred. Please contact support.'}), 500
 
 def optimize_with_ai(current: Dict, budget: int, requirements: Dict) -> Dict[str, Any]:
     """Use AI to optimize resource allocation for cost"""


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/27](https://github.com/CreoDAMO/REPAR/security/code-scanning/27)

The correct way to fix this issue is to prevent exception data from being sent to end users. Instead of returning some variant of `str(e)` to the client, return a generic message such as "Internal server error. Please contact support if the problem persists," and log the detailed error on the server for future troubleshooting. 

Specifically, in `ace/ai-sidecar/ace_sidecar.py`, inside the exception handler within the `optimize_cost` function, replace:

```python
return jsonify({'error': str(e)}), 500
```

with:

```python
return jsonify({'error': 'An internal error has occurred. Please contact support.'}), 500
```

No new imports are needed, the logger call remains unchanged, and the rest of the code and API behavior is unaffected except that clients no longer see details of the crash.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
