### PR TITLE
Potential fix for code scanning alert no. 33: Shell command built from environment values

### DIFF
--- a/vm-infrastructure/cli/commands/deploy.js
+++ b/vm-infrastructure/cli/commands/deploy.js
@@ -5,7 +5,7 @@
 const chalk = require('chalk');
 const ora = require('ora');
 const inquirer = require('inquirer');
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 const { promisify } = require('util');
 const execAsync = promisify(exec);
 
@@ -222,7 +222,20 @@ async function deployLocalKVM(options) {
     });
     
     // Start VM in background
-    await execAsync(`${qemuCmd} > ${vmDir}/vm.log 2>&1 &`);
+    // Safely spawn QEMU, redirect output to vm.log
+    const shellQuote = require('shell-quote');
+    const fs3 = require('fs');
+    const logFile = fs3.createWriteStream(path.join(vmDir, 'vm.log'));
+    // Parse command line into program and argument list
+    const parsedCmd = shellQuote.parse(qemuCmd); // returns array, first is binary
+    const qemuBinary = parsedCmd[0];
+    const qemuArgs = parsedCmd.slice(1);
+    const qemuProcess = spawn(qemuBinary, qemuArgs, {
+      detached: true,
+      stdio: ['ignore', logFile, logFile],
+      cwd: vmDir
+    });
+    qemuProcess.unref();
     
     // Save VM info
     const vmInfo = {

--- a/vm-infrastructure/cli/package.json
+++ b/vm-infrastructure/cli/package.json
@@ -32,7 +32,8 @@
     "ssh2": "^1.15.0",
     "dockerode": "^4.0.2",
     "proxmox-api": "^1.1.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "shell-quote": "^1.8.3"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/33](https://github.com/CreoDAMO/REPAR/security/code-scanning/33)

To fix this issue, we should avoid constructing a shell command with interpolated variables that may contain shell metacharacters or spaces. Instead of passing the command as a shell string to `execAsync`/`exec`, we should use `child_process.spawn`, `child_process.execFile`, or their async equivalents. These accept the program and arguments as separate parameters, preventing shell interpretation and injection risks.

For this fix, focus on replacing the line:

```js
await execAsync(`${qemuCmd} > ${vmDir}/vm.log 2>&1 &`);
```

with code that runs the QEMU command directly, passing all relevant arguments as an array to `spawn` or `execFile`, and handling output redirection to the log file programmatically (i.e., by specifying the stdout/stderr streams as writable file streams).

This requires:
- Parsing `qemuCmd` (returned by `buildQEMUCommand`) into the binary and argument list.
- Using `child_process.spawn` in detached/background mode.
- Redirecting output to `${vmDir}/vm.log` using Node's `fs.createWriteStream`.

Assume `buildQEMUCommand` returns a string suitable for shell use (e.g., `'qemu-system-x86_64 ...args...'`). We'll need to split this into command and arguments safely (likely using a library such as `shell-quote` or minimal manual parsing, since only minimal code changes are allowed per instructions).

Necessary changes:
- Replace execAsync on line 225 with a call to `child_process.spawn`, using correct argument parsing.
- Add `fs.createWriteStream` and use the streams for stdout/stderr.
- Ensure the process is detached and runs in background.
- Add required imports at the top: `const { spawn } = require('child_process');` (if not present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
