### PR TITLE
Potential fix for code scanning alert no. 32: Shell command built from environment values

### DIFF
--- a/vm-infrastructure/cli/commands/deploy.js
+++ b/vm-infrastructure/cli/commands/deploy.js
@@ -5,9 +5,10 @@
 const chalk = require('chalk');
 const ora = require('ora');
 const inquirer = require('inquirer');
-const { exec, spawn } = require('child_process');
+const { exec, execFile, spawn } = require('child_process');
 const { promisify } = require('util');
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 module.exports = async function deployCommand(options) {
   console.log(chalk.cyan('\n🚀 Deploying Aequitas Protocol Zone VM\n'));
@@ -207,7 +208,7 @@ async function deployLocalKVM(options) {
     
     // Create cloud-init ISO
     const seedPath = path.join(vmDir, 'seed.iso');
-    await execAsync(`cloud-localds ${seedPath} ${cloudInitPath}`);
+    await execFileAsync('cloud-localds', [seedPath, cloudInitPath]);
     
     spinner.text = 'Starting VM with QEMU/KVM...';
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/32](https://github.com/CreoDAMO/REPAR/security/code-scanning/32)

The best fix is to avoid dynamic shell interpretation of file paths and other potentially unsafe inputs. Instead of building a single string to be evaluated by the shell (as with ``execAsync(`cloud-localds ${seedPath} ${cloudInitPath}`)``), use an API that takes separate arguments and does not invoke the shell. For Node.js, `child_process.execFile`/`execFileSync`/`spawn` allow you to specify the command and its arguments as an array, avoiding shell interpretation. Specifically, replace `execAsync` with direct invocation of `execFile` via `promisify`. This requires you to ensure that you pass each argument item separately, so the external process receives them unambigously, regardless of any spaces, quotes, or shell metacharacters.

In vm-infrastructure/cli/commands/deploy.js, update line 210 and the construction of related shell commands to use `execFileAsync` rather than `execAsync`, and provide the arguments array explicitly: `execFileAsync("cloud-localds", [seedPath, cloudInitPath])`. You'll need to import/promisify child_process.execFile similar to how execAsync is currently used.

You will need:
- To import/promisify `execFile`.
- To call `execFileAsync()` in place of `execAsync()` for the `cloud-localds` command.
- (Optionally) you may want to update comments to reflect that this is now securely constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
