### PR TITLE
Potential fix for code scanning alert no. 31: Shell command built from environment values

### DIFF
--- a/vm-infrastructure/cli/commands/deploy.js
+++ b/vm-infrastructure/cli/commands/deploy.js
@@ -197,7 +197,14 @@ async function deployLocalKVM(options) {
     
     // Create disk from base image and resize
     const diskPath = path.join(vmDir, 'disk.qcow2');
-    await execAsync(`qemu-img create -f qcow2 -F qcow2 -b ${baseImagePath} ${diskPath} ${options.storage}G`);
+    await execFileAsync('qemu-img', [
+      'create',
+      '-f', 'qcow2',
+      '-F', 'qcow2',
+      '-b', baseImagePath,
+      diskPath,
+      `${options.storage}G`
+    ]);
     
     spinner.text = 'Generating cloud-init configuration...';
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/31](https://github.com/CreoDAMO/REPAR/security/code-scanning/31)

To fix this issue, we should avoid building shell command strings by interpolation when inserting environment or user-controlled paths. Instead, we should use an API (such as `child_process.execFile` or `child_process.spawn`) that allows passing the command and its arguments as separate parameters, bypassing the shell’s argument parsing and interpretation. For the `qemu-img create` invocation at line 200, rather than concatenating the file paths into a single command string, build an array of arguments and pass them to `execFileAsync`. This ensures that spaces or special characters in the file paths are correctly handled. You need to change the call at line 200 from `execAsync` with a template literal to use `execFileAsync` with an array of arguments. Ensure that all required arguments for the command are included, and update imports (none needed here since `execFileAsync` is already available).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
