### PR TITLE
Potential fix for code scanning alert no. 26: Information exposure through an exception

### DIFF
--- a/ace/ai-sidecar/ace_sidecar.py
+++ b/ace/ai-sidecar/ace_sidecar.py
@@ -333,7 +333,7 @@ Respond with JSON:
             'optimized_allocation': current,
             'estimated_cost_repar': budget,
             'savings_percent': 0.0,
-            'error': str(e)
+            'error': 'An internal error has occurred.'
         }
 
 def main():


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/26](https://github.com/CreoDAMO/REPAR/security/code-scanning/26)

To fix the issue, the code should ensure that exception details (including the stringified exception message returned by `str(e)`) are **not sent to API clients**. Instead, these details should be logged securely on the server (which is already done), while clients receive only a generic and non-sensitive error message. Specifically, in `optimize_with_ai`, the returned dictionary upon catching an exception should not include the key `'error': str(e)`, but should use a more generic message (e.g., `'error': 'An internal error has occurred.'`). 

All changes are localized to `ace/ai-sidecar/ace_sidecar.py`, specifically lines 332–336, inside the `optimize_with_ai` function. No new imports are necessary, and the existing logging semantics are retained. Functionality otherwise remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
