### PR TITLE
Potential fix for code scanning alert no. 30: Shell command built from environment values

### DIFF
--- a/vm-infrastructure/cli/commands/deploy.js
+++ b/vm-infrastructure/cli/commands/deploy.js
@@ -190,7 +190,7 @@ async function deployLocalKVM(options) {
     // Download base image if it doesn't exist
     const fs2 = require('fs');
     if (!fs2.existsSync(baseImagePath)) {
-      await execAsync(`wget -O ${baseImagePath} ${baseImageUrl}`);
+      await execFileAsync('wget', ['-O', baseImagePath, baseImageUrl]);
     }
     
     spinner.text = 'Creating virtual disk from base image...';


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/30](https://github.com/CreoDAMO/REPAR/security/code-scanning/30)

To fix this issue, the dynamically built shell command should be replaced with a safer invocation that supplies arguments as an array, preventing the shell from misinterpreting special characters, and eliminating any possibility for injection. Instead of using `execAsync` (which runs a command in a shell), the code should use `execFileAsync`, passing `wget` as the command and each parameter as a separate array element.  
In vm-infrastructure/cli/commands/deploy.js, in the `deployLocalKVM` function, replace line 193:

- Change ``` await execAsync(`wget -O ${baseImagePath} ${baseImageUrl}`); ```  
  to  
  ``` await execFileAsync('wget', ['-O', baseImagePath, baseImageUrl]); ```  

This ensures paths with spaces or special characters are handled safely, and that `baseImagePath` is not interpreted by the shell. No additional packages are needed beyond the existing `'child_process'` and promisified versions.  

You should make this change at line 193 and provide enough context in your replacement block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
