### PR TITLE
Potential fix for code scanning alert no. 25: Information exposure through an exception

### DIFF
--- a/ace/ai-sidecar/ace_sidecar.py
+++ b/ace/ai-sidecar/ace_sidecar.py
@@ -254,8 +254,8 @@ Respond with JSON:
         return jsonify(result), 200
         
     except Exception as e:
-        logger.error(f"Audit analysis error: {e}")
-        return jsonify({'error': str(e)}), 500
+        logger.error("Audit analysis error:", exc_info=True)
+        return jsonify({'error': 'An internal error has occurred. Please contact support.'}), 500
 
 @app.route('/api/v1/optimize-cost', methods=['POST'])
 def optimize_cost():


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/25](https://github.com/CreoDAMO/REPAR/security/code-scanning/25)

To fix the problem, the API should avoid sending the exception’s string representation (`str(e)`) directly in the JSON error response to the user. Instead, return a generic, user-friendly error message. Optionally, log the full stack trace and exception internally using the `logger`, so support and dev teams can inspect issues without exposing sensitive data to users. This fix should be made where the vulnerable pattern occurs (line 258), in the `/api/v1/analyze-audit` endpoint handler code block. No external dependencies are needed; you already use a logger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
