### PR TITLE
Potential fix for code scanning alert no. 29: Shell command built from environment values

### DIFF
--- a/vm-infrastructure/cli/commands/deploy.js
+++ b/vm-infrastructure/cli/commands/deploy.js
@@ -101,14 +101,12 @@ async function deployDocker(options) {
     spinner.text = 'Building Aequitas Zone image...';
     
     // Build image using docker-compose
-    const buildCmd = `cd ${dockerDir} && docker-compose build`;
-    await execAsync(buildCmd);
+    await execFileAsync('docker-compose', ['build'], { cwd: dockerDir });
     
     spinner.text = 'Starting container...';
     
     // Start container using docker-compose
-    const upCmd = `cd ${dockerDir} && docker-compose up -d`;
-    await execAsync(upCmd);
+    await execFileAsync('docker-compose', ['up', '-d'], { cwd: dockerDir });
     
     // Wait for container to be ready
     spinner.text = 'Waiting for node to be ready...';


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/29](https://github.com/CreoDAMO/REPAR/security/code-scanning/29)

The best way to fix this problem is to avoid interpolating dynamic or environment values (like `dockerDir`) directly into the shell command string passed to `exec`.  
Instead, invoke the relevant command using the `execFile` (or `execFileSync`) or `spawn` APIs, passing command-line arguments separately. This approach prevents shell expansion/interpolation and protects against command injection. Specifically:

- Replace `execAsync(buildCmd)` and `execAsync(upCmd)` with `execFileAsync` (or promisified `execFile`), running `docker-compose` as the executable with arguments,
- Set the working directory via the `cwd` property in the options object passed to `execFileAsync` so that directory changes occur safely (no need for `cd ...` shell commands).
- If any environment variables or special options are needed, pass them explicitly via the `options` argument rather than via string interpolation.

You will need:
- To change lines in `deployDocker` where build and up commands are executed.
- Make no changes outside the supplied code snippet region.
- No new npm packages needed—just use the already required Node.js `child_process` module and its `execFileAsync` (already defined).
- Provide the working directory via the options object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
