### PR TITLE
Potential fix for code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/ace/ai-sidecar/ace_sidecar.py
+++ b/ace/ai-sidecar/ace_sidecar.py
@@ -100,7 +100,7 @@ def predict_placement():
         
     except Exception as e:
         logger.error(f"Prediction error: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 def predict_with_ai(workload_type: str, duration: int, nodes: List[Dict], user_did: str) -> Dict[str, Any]:
     """Use NVIDIA NIM to predict optimal placement"""


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/24](https://github.com/CreoDAMO/REPAR/security/code-scanning/24)

The fix is to avoid returning the stringified exception object to the client in the error response for the `/api/v1/predict-placement` POST endpoint. Instead, log the exception -- this is already done by the logger statement at line 102 -- and return a generic error message to the client, such as `"An internal error has occurred."` or similar. Only the logging subsystem should see the actual error/exception detail.

Specifically, in `ace/ai-sidecar/ace_sidecar.py`, replace the line:
```python
return jsonify({'error': str(e)}), 500
```
with:
```python
return jsonify({'error': 'An internal error has occurred.'}), 500
```
No additional imports or method definitions are required, since logging is already used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
