### PR TITLE
Potential fix for code scanning alert no. 34: Clear-text logging of sensitive information

### DIFF
--- a/auditor/agents/aequitas_ai.py
+++ b/auditor/agents/aequitas_ai.py
@@ -51,7 +51,7 @@ class AequitasAI:
         print(f"✅ Aequitas AI initialized with NVIDIA NIM")
         print(f"   Model: {self.model}")
         print(f"   Endpoint: {self.nim_endpoint}")
-        print(f"   API Key: {'*' * (len(self.api_key) - 4) + self.api_key[-4:]}")
+        print(f"   API Key: [REDACTED]")
     
     def _build_analyst_persona(self) -> str:
         """


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/34](https://github.com/CreoDAMO/REPAR/security/code-scanning/34)

To address the issue, the code that logs the API key (even partially masked) on line 54 of `auditor/agents/aequitas_ai.py` should be removed or altered so that no part of the sensitive value is printed. The desired functionality is simply to verify initialization in logs, which can be done without references to the actual key.  
Specifically, in the constructor of `AequitasAI`, replace:
```python
print(f"   API Key: {'*' * (len(self.api_key) - 4) + self.api_key[-4:]}")
```
with a safe message indicating that an API key was loaded, e.g.:
```python
print("   API Key: [REDACTED]")
```
Or, simply omit the API key altogether from log output.  
No new imports or definitions are needed for this update.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
