### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -416,6 +416,7 @@ jobs:
   # ============================================
   post-deploy-summary:
     name: Post-Deployment Summary
+    permissions: {}
     runs-on: ubuntu-latest
     needs: [build, deploy-docker, deploy-ace]
     if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/40](https://github.com/CreoDAMO/REPAR/security/code-scanning/40)

The best fix is to add a `permissions` key to the `post-deploy-summary` job (lines 417–455) specifying the minimum required permissions. Since this job only appears to write to `$GITHUB_STEP_SUMMARY` and does not interact with repository contents, issues, or PRs, the correct minimal permission block is `permissions: {}` (none), which is valid YAML/GitHub Actions syntax for denying all GITHUB_TOKEN permissions (the job still has read access to the summary feature). To implement, insert a `permissions: {}` line immediately under line 418 (under the job’s `name:`).

**What is needed:**  
- Insert `permissions: {}` on a new line directly after `name: Post-Deployment Summary` (line 418).
- No imports, new definitions, or changes elsewhere are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
