### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -360,6 +360,8 @@ jobs:
   deploy-ace:
     name: Deploy via ACE (Advanced Computing Engine)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/39](https://github.com/CreoDAMO/REPAR/security/code-scanning/39)

To fix the issue, we need to set an explicit, restrictive `permissions` block for jobs that do not already specify one, especially for the `deploy-ace` job highlighted by CodeQL. The recommended minimal starting point is `permissions: { contents: read }`, which allows the job to read repository contents (e.g., for code checkout) but not to perform any write actions. If certain steps in the job require broader permissions (e.g., to create a release, comment on PRs, etc.), those can be extended. Based on the 'deploy-ace' job steps shown (checking out code, downloading artifacts, deploying, and generating summaries), only read access to repository contents seems necessary.

You should add the following block under the job definition for `deploy-ace`  
```yaml
permissions:
  contents: read
```
Place this between line 362 (`runs-on: ubuntu-latest`) and line 363 (`needs: [build]`). No additional imports or methods are required; only this YAML snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
