### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -282,6 +282,8 @@ jobs:
   deploy-docker:
     name: Deploy via Docker
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/38](https://github.com/CreoDAMO/REPAR/security/code-scanning/38)

The fix is to add an explicit `permissions` block to the `deploy-docker` job, restricting permissions to only those that are strictly necessary. At minimum, if the job is only reading repository contents and not modifying anything, then `contents: read` is recommended. This can be done by adding the following under the `deploy-docker:` job key, at the same position as other jobs (such as `deploy-ace`), generally right before or after `runs-on: ubuntu-latest`. No additional dependencies, imports, or code logic changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
