### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -237,6 +237,8 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build, init-testnet]
     if: startsWith(github.ref, 'refs/tags/')
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/37](https://github.com/CreoDAMO/REPAR/security/code-scanning/37)

**General fix:**  
Add an explicit `permissions` block to the `create-release` job, granting only those permissions required to create a release (typically `contents: write`). Place this block at the same indentation level as `runs-on` (i.e., as a sibling key inside the job definition).

**Detailed fix:**  
- In `.github/workflows/blockchain-build-and-deploy.yml`, locate the `create-release:` job block (starts at line 237).
- Just after `runs-on: ubuntu-latest` (currently line 239), insert:
  ```yaml
    permissions:
      contents: write
  ```
- This ensures only the required permission (`contents: write`) is provided to the GITHUB_TOKEN for this job.
- No new imports or additional definitions are needed, as this is a YAML workflow file edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
