### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -182,6 +182,8 @@ jobs:
   init-testnet:
     name: Initialize Local Testnet
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build]
     if: success()
     


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/36](https://github.com/CreoDAMO/REPAR/security/code-scanning/36)

To fix the problem, add a `permissions` block to the `init-testnet` job, specifying only the minimal permissions required for the job: `contents: read`. This ensures that the job only has read access to repository code/content and that the `GITHUB_TOKEN` is not granted unnecessary privileges.  
Specifically, update the `.github/workflows/blockchain-build-and-deploy.yml` file in the `init-testnet` job definition (right after `name: ...`/`runs-on: ...` and before any steps), and insert:

```yaml
permissions:
  contents: read
```

No new imports, methods, or variable definitions are required – it's a pure YAML workflow policy change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
