### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blockchain-build-and-deploy.yml
+++ b/.github/workflows/blockchain-build-and-deploy.yml
@@ -44,6 +44,8 @@ jobs:
   # ============================================
   build:
     name: Build & Test Blockchain
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/35](https://github.com/CreoDAMO/REPAR/security/code-scanning/35)

To fix this issue, you should add a `permissions` block to the `build` job at line 46 (right under `name: Build & Test Blockchain`). As this job only needs to check out code and upload GitHub Actions artifacts, it typically requires only `contents: read` access—this allows it to read the repository contents required for build/test, but not write or delete anything in the repo. If future steps are added that do require further access, they can be specified, but for now, `contents: read` is the minimal starting point per CodeQL guidance.

**How to fix:**  
- In the `.github/workflows/blockchain-build-and-deploy.yml` file, add the following block under line 46 (or after, to follow indentation conventions and grouping):
  ```yaml
  permissions:
    contents: read
  ```
- Ensure indentation matches the job-level (`build` job) keys.
- No changes to job logic are required, and no new imports or dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
