### PR TITLE
Potential fix for code scanning alert no. 41: Clear-text logging of sensitive information

### DIFF
--- a/apex/satellite_protocol.py
+++ b/apex/satellite_protocol.py
@@ -468,7 +468,12 @@ if __name__ == "__main__":
     # Create mobile validator satellites
     mobile1 = assp.create_mobile_satellite("validator-001")
     
-    logger.info(f"\n🌍 Constellation Status:\n{json.dumps(assp.get_constellation_status(), indent=2)}\n")
+    # Prepare redacted constellation status with position omitted for logging
+    constellation_status = assp.get_constellation_status()
+    for sat in constellation_status['satellites']:
+        if 'position' in sat:
+            sat['position'] = {"lat": "REDACTED", "lon": "REDACTED", "alt_km": "REDACTED"}
+    logger.info(f"\n🌍 Constellation Status:\n{json.dumps(constellation_status, indent=2)}\n")
     
     # Test packet routing
     packet = SatellitePacket(


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/41](https://github.com/CreoDAMO/REPAR/security/code-scanning/41)

To fix the issue, we must ensure that sensitive positional data (latitude, longitude, altitude) is not logged in clear text via the existing info logs. The best solution is to sanitize the data before logging by either:
- removing the positional field from the output, or
- redacting it (e.g., replace with `"REDACTED"` or omit from the log).

Specifically:
- In the integration test block, just before logging Constellation Status (line 471), remove or redact the `position` field from each satellite entry in the status dictionary, or construct a new status dictionary omitting these positional entries before logging.
- Do not alter the underlying `get_constellation_status()` method unless required for privacy throughout the codebase; for minimal-impact, sanitize just before logging.

Necessary changes:
- In apex/satellite_protocol.py: Right before line 471, prepare a sanitized version of the constellation status data, redacting or removing the `position` property from each satellite, then log that sanitized version instead.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
