### PR TITLE
Potential fix for code scanning alert no. 42: Clear-text logging of sensitive information

### DIFF
--- a/apex/satellite_protocol.py
+++ b/apex/satellite_protocol.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime
 from enum import Enum
 from abc import ABC, abstractmethod
+import copy
 
 from post_quantum import PostQuantumCrypto, PQCKeyPair
 
@@ -444,6 +445,16 @@ class AequitasSatelliteProtocol:
             for sender, receiver, ts in self.packet_log
         ]
 
+    def get_redacted_constellation_status(self) -> Dict[str, Any]:
+        """
+        Return constellation status with sensitive position fields redacted.
+        """
+        status = copy.deepcopy(self.get_constellation_status())
+        # Redact position info for every satellite
+        for sat in status.get('satellites', []):
+            if 'position' in sat:
+                sat['position'] = {"lat": "REDACTED", "lon": "REDACTED", "alt_km": "REDACTED"}
+        return status
 
 # Global satellite protocol instance
 _global_assp: Optional[AequitasSatelliteProtocol] = None
@@ -468,12 +479,9 @@ if __name__ == "__main__":
     # Create mobile validator satellites
     mobile1 = assp.create_mobile_satellite("validator-001")
     
-    # Prepare redacted constellation status with position omitted for logging
-    constellation_status = assp.get_constellation_status()
-    for sat in constellation_status['satellites']:
-        if 'position' in sat:
-            sat['position'] = {"lat": "REDACTED", "lon": "REDACTED", "alt_km": "REDACTED"}
-    logger.info(f"\n🌍 Constellation Status:\n{json.dumps(constellation_status, indent=2)}\n")
+    # Log only redacted constellation status to avoid leaking sensitive positional data
+    redacted_constellation_status = assp.get_redacted_constellation_status()
+    logger.info(f"\n🌍 Constellation Status:\n{json.dumps(redacted_constellation_status, indent=2)}\n")
     
     # Test packet routing
     packet = SatellitePacket(


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/REPAR/security/code-scanning/42](https://github.com/CreoDAMO/REPAR/security/code-scanning/42)

To robustly prevent logging of sensitive position information, the redaction should be performed in a dedicated function that creates and returns an explicit, deeply copied redacted version of constellation status, rather than mutating the original object fields in-place. This approach ensures that even if future changes are made to the logging mechanism, the sensitive position information can never be accidentally logged. 

Specifically, add a new helper method (e.g., `get_redacted_constellation_status()`) to the protocol class. This method will generate the same constellation status as `get_constellation_status()`, but replaces each satellite's `'position'` field with redacted placeholders. The integration test block should call this new helper to log a known-safe redacted view, and not rely on direct mutation of the dict structure. No external dependencies beyond the standard library are needed, but `copy.deepcopy` should be used to avoid accidental mutation of underlying state.

All changes are within `apex/satellite_protocol.py`. Only edits within the shown code can be made.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
